### PR TITLE
detect relative URL pmtiles correctly [#152]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.1.2
+* Fix pmtiles URL detection on relative paths [#152]
+
+# 3.1.1
+* Detect pmtiles URLs by using URL parsing, which handles query parameters [#147]
+
+# 3.1.0
+* add `queryTileFeaturesDebug` back in for basic interactions (You should use MapLibre if you want interactivity)
+
 # 3.0.0
 
 * Unexport `PMTiles` because you shouldn't be depending on the one bundled in this library.

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="pixelmatch.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             html {

--- a/examples/comparison.html
+++ b/examples/comparison.html
@@ -9,7 +9,7 @@
         <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.css" crossorigin="anonymous">
         <script src="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.js" crossorigin="anonymous"></script>
         <script src="https://unpkg.com/@maplibre/maplibre-gl-leaflet@0.0.20/leaflet-maplibre-gl.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <style>
             #parent {
                 display:flex;

--- a/examples/fonts.html
+++ b/examples/fonts.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="https://unpkg.com/leaflet-hash@0.2.1/leaflet-hash.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
 
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Work+Sans:wght@100..900&family=Petrona:wght@100..900&family=Raleway:wght@100..900" rel="stylesheet">

--- a/examples/inset.html
+++ b/examples/inset.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             #map {

--- a/examples/labels.html
+++ b/examples/labels.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="https://unpkg.com/leaflet-hash@0.2.1/leaflet-hash.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             body, #map {

--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="https://unpkg.com/leaflet-hash@0.2.1/leaflet-hash.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             body, #map {

--- a/examples/multi_source.html
+++ b/examples/multi_source.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="https://unpkg.com/leaflet-hash@0.2.1/leaflet-hash.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             body, #map {

--- a/examples/pmtiles.html
+++ b/examples/pmtiles.html
@@ -4,7 +4,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             body, #map {

--- a/examples/pmtiles_headers.html
+++ b/examples/pmtiles_headers.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="https://unpkg.com/pmtiles@3.0.3/dist/pmtiles.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             body, #map {

--- a/examples/sandwich.html
+++ b/examples/sandwich.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="https://unpkg.com/leaflet-hash@0.2.1/leaflet-hash.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             body, #map {

--- a/examples/sprites.html
+++ b/examples/sprites.html
@@ -5,7 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
         <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
         <script src="https://unpkg.com/leaflet-hash@0.2.1/leaflet-hash.js"></script>
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             body, #map {

--- a/examples/static.html
+++ b/examples/static.html
@@ -2,7 +2,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <script src="https://unpkg.com/protomaps-leaflet@3.1.1/dist/protomaps-leaflet.min.js"></script>
+        <script src="https://unpkg.com/protomaps-leaflet@3.1.2/dist/protomaps-leaflet.min.js"></script>
         <!-- <script src="../dist/protomaps-leaflet.js"></script> -->
         <style>
             #map {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protomaps-leaflet",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "protomaps-leaflet",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/point-geometry": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protomaps-leaflet",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "files": [
     "dist",
     "src"

--- a/src/view.ts
+++ b/src/view.ts
@@ -242,8 +242,7 @@ export const sourcesToViews = (options: SourceOptions) => {
     let source: TileSource;
     if (typeof o.url === "string") {
       if (
-        o.url.startsWith("http") &&
-        new URL(o.url).pathname.endsWith(".pmtiles")
+        new URL(o.url, "http://example.com").pathname.endsWith(".pmtiles")
       ) {
         source = new PmtilesSource(o.url, true);
       } else {

--- a/src/view.ts
+++ b/src/view.ts
@@ -241,9 +241,7 @@ export const sourcesToViews = (options: SourceOptions) => {
     const maxDataZoom = o.maxDataZoom || 15;
     let source: TileSource;
     if (typeof o.url === "string") {
-      if (
-        new URL(o.url, "http://example.com").pathname.endsWith(".pmtiles")
-      ) {
+      if (new URL(o.url, "http://example.com").pathname.endsWith(".pmtiles")) {
         source = new PmtilesSource(o.url, true);
       } else {
         source = new ZxySource(o.url, true);

--- a/test/view.test.ts
+++ b/test/view.test.ts
@@ -107,3 +107,8 @@ test("sources to views with pmtiles parameters", async () => {
   const v = sourcesToViews({ url: "http://example.com/foo.pmtiles?k=v" });
   assert.ok(v.get("").tileCache.source instanceof PmtilesSource);
 });
+
+test("sources to views local param", async () => {
+  const v = sourcesToViews({ url: "foo.pmtiles" });
+  assert.ok(v.get("").tileCache.source instanceof PmtilesSource);
+});


### PR DESCRIPTION
* put in a placeholder URL to let URL() parse relative URLs without http prefix.