### PR TITLE
swap left shift operators for Math.pow for scoped projection/unprojection

### DIFF
--- a/src/frontends/static.ts
+++ b/src/frontends/static.ts
@@ -36,7 +36,7 @@ const instancedProject = (origin: Point, displayZoom: number) => {
       (projected.x + MAXCOORD) / (MAXCOORD * 2),
       1 - (projected.y + MAXCOORD) / (MAXCOORD * 2),
     );
-    return normalized.mult((1 << displayZoom) * 256).sub(origin);
+    return normalized.mult((1 * Math.pow(2, displayZoom)) * 256).sub(origin);
   };
 };
 
@@ -44,7 +44,7 @@ const instancedUnproject = (origin: Point, displayZoom: number) => {
   return (point: Point) => {
     const normalized = new Point(point.x, point.y)
       .add(origin)
-      .div((1 << displayZoom) * 256);
+      .div((1 * Math.pow(2, displayZoom)) * 256);
     const projected = new Point(
       normalized.x * (MAXCOORD * 2) - MAXCOORD,
       (1 - normalized.y) * (MAXCOORD * 2) - MAXCOORD,

--- a/src/frontends/static.ts
+++ b/src/frontends/static.ts
@@ -36,7 +36,7 @@ const instancedProject = (origin: Point, displayZoom: number) => {
       (projected.x + MAXCOORD) / (MAXCOORD * 2),
       1 - (projected.y + MAXCOORD) / (MAXCOORD * 2),
     );
-    return normalized.mult((1 * Math.pow(2, displayZoom)) * 256).sub(origin);
+    return normalized.mult(2 ** displayZoom * 256).sub(origin);
   };
 };
 
@@ -44,7 +44,7 @@ const instancedUnproject = (origin: Point, displayZoom: number) => {
   return (point: Point) => {
     const normalized = new Point(point.x, point.y)
       .add(origin)
-      .div((1 * Math.pow(2, displayZoom)) * 256);
+      .div(2 ** displayZoom * 256);
     const projected = new Point(
       normalized.x * (MAXCOORD * 2) - MAXCOORD,
       (1 - normalized.y) * (MAXCOORD * 2) - MAXCOORD,


### PR DESCRIPTION
With the caveat that I'm not very fluent in bitwise operators, and I'm not totally sure I can point to the part of the Javascript spec that explains why this fix works, and the left shift operators don't...but it seems like, in Safari at least, `1 << 15.5 == 1 << 15`, which is unexpected.

This branch uses `Math.pow` instead — where (again, in Safari) `Math.pow(2, 15.5) != Math.pow(2, 15)`, which is expected.

fixes #171