### PR TITLE
Adjust and add a few layer types

### DIFF
--- a/src/frontends/leaflet.ts
+++ b/src/frontends/leaflet.ts
@@ -43,8 +43,8 @@ const reflect = (promise: Promise<Status>) => {
 type DoneCallback = (error?: Error, tile?: HTMLElement) => void;
 type KeyedHtmlCanvasElement = HTMLCanvasElement & { key: string };
 
-interface LeafletLayerOptions {
-  bounds?: number[][];
+export interface LeafletLayerOptions extends L.GridLayerOptions {
+  bounds?: L.LatLngBoundsExpression;
   attribution?: string;
   debug?: string;
   lang?: string;
@@ -61,8 +61,12 @@ interface LeafletLayerOptions {
   backgroundColor?: string;
 }
 
-const leafletLayer = (options: LeafletLayerOptions = {}): unknown => {
+const leafletLayer = (options: LeafletLayerOptions = {}) => {
   class LeafletLayer extends L.GridLayer {
+    public paintRules: PaintRule[];
+    public labelRules: LabelRule[];
+    public backgroundColor?: string;
+
     constructor(options: LeafletLayerOptions = {}) {
       if (options.noWrap && !options.bounds)
         options.bounds = [
@@ -273,7 +277,7 @@ const leafletLayer = (options: LeafletLayerOptions = {}): unknown => {
 
     // a primitive way to check the features at a certain point.
     // it does not support hover states, cursor changes, or changing the style of the selected feature,
-    // so is only appropriate for debuggging or very basic use cases.
+    // so is only appropriate for debugging or very basic use cases.
     // those features are outside of the scope of this library:
     // for fully pickable, interactive features, use MapLibre GL JS instead.
     public queryTileFeaturesDebug(

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ export * from "./frontends/leaflet";
 export * from "./symbolizer";
 export * from "./task";
 export * from "./default_style/style";
-export * from "./default_style/themes";
 export * from "./painter";
 export * from "./tilecache";
 export * from "./view";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./frontends/leaflet";
 export * from "./symbolizer";
 export * from "./task";
 export * from "./default_style/style";
+export * from "./default_style/themes";
 export * from "./painter";
 export * from "./tilecache";
 export * from "./view";


### PR DESCRIPTION
Hi @bdon, I've been so excited to get my hands on Protomaps in LeafletJS over the last few weeks and am really loving this whole ecosystem you're building. Thank you!

---

I found that I was recreating some of the types in my callsites (and even copy-pasting the themes), and wanted to see if you'd be open to incorporating these changes back into the source.

This PR:

- Adjusts the layer class constructor return to **not** be `unknown` so that the its full TS is available at the consumer/callsite.
- Adds/types a few public layer class props (`paintRules`, `labelRules`, and `backgroundColor`), which for example I have been adjusting on the layer instance and then calling `myLayer.rerenderTiles()`. I'm also happy to spend more time on this and type out the other class props that may be public or private, too.
- Exports and slightly adjusts the layer constructor options, which I have also been dealing with in my recent usage of the layer.
- ~Exports the theme interface and theme definitions, which again have been used on my end recently.~